### PR TITLE
Update unit.json.j2

### DIFF
--- a/ansible/templates/unit.json.j2
+++ b/ansible/templates/unit.json.j2
@@ -36,8 +36,7 @@
           },
           "action": {
             "return": 302,
-            "location": "https://forms.gle/2a8HQUNJRAcvq5UGA"
-          }
+            "location": "https://docs.google.com/forms/d/e/1FAIpQLSf_847hNXtLGikR-XeDy1uT1AKd24DpHnt5UQh2i8ORRu7u-w/viewform?usp=send_form"          }
       },
       {
           "match": {


### PR DESCRIPTION
https://developers.googleblog.com/en/google-url-shortener-links-will-no-longer-be-available/

Even though an Aug 1 update to the above retracts the service withdrawal somewhat, it's safer to link to the actual form for now.

-----------------
This PR is untested by me. 

I noticed that a previous change to this file was accompanied by bumped up version numbers in n2t/__init__.py and pyproject.toml . I don't know your protocol for this, and am only pointing out that I didn't attempt any such change.