### PR TITLE
Add accessibility statement and fix pre/code dark-mode contrast

### DIFF
--- a/legacy_e_files/e/footer.html
+++ b/legacy_e_files/e/footer.html
@@ -13,6 +13,8 @@
         &copy; 2007-<script type="text/javascript">
 	document.write(new Date().getFullYear());</script>
 	The Regents of the University of California
+	<br/>
+	<a href="/_accessibility.html">Accessibility Statement</a>
 	</p>
       </div>
       <!-- div class="col-xs-12 col-sm-4">

--- a/n2t/templates/accessibility.html
+++ b/n2t/templates/accessibility.html
@@ -1,0 +1,15 @@
+{% extends "base.html" %}
+{% block title %}Accessibility{% endblock %}
+{% block headertext %} - Accessibility{% endblock %}
+{% block main %}
+    <h1>Accessibility Statement</h1>
+    <div>
+    <p>As part of the University of California, CDL is required to follow the
+    <a href="https://www.ucop.edu/electronic-accessibility/initiative/policy.html">University of California Information Technology Accessibility Policy</a>
+    to help ensure that as broad a population as possible may access, benefit
+    from, and contribute to the University's electronic programs and services.
+    The Policy requires that all web content in N2T.net complies with WCAG 2.1
+    Guidelines at level AA success criteria. Accordingly, users are responsible
+    for ensuring that content they provide to N2T.net meets this standard.</p>
+    </div>
+{% endblock %}

--- a/n2t/templates/base.html
+++ b/n2t/templates/base.html
@@ -27,15 +27,14 @@
         a successful match will either redirect to the registered target, or present
         information about the matched definition.</p>
     <p>Identifiers take the form:</p>
-    <pre>
-scheme:prefix/value
-    </pre>
+    <pre><code>scheme:prefix/value</code></pre>
         <p>The service API description is available at <a href="/api">/api</a>.</p>
         <p>A list of schemes registered with this service is available on the <a href="/_schemes.html">schemes page</a>.</p>
     </div>
     {% endblock %}
 </main>
-<footer>N2T, {{ environment }} environment, version {{ version }}</footer>
+<footer>N2T, {{ environment }} environment, version {{ version }}
+ &middot; <a href="/_accessibility.html">Accessibility</a></footer>
 {% endblock %}
 {% block addendum %}
 {% endblock %}

--- a/n2t/templates/index.html
+++ b/n2t/templates/index.html
@@ -8,9 +8,7 @@
         a successful match will either redirect to the registered target or present
         information about the matched definition.</p>
     <p>Identifiers take the form:</p>
-    <pre>
-scheme:prefix/value
-    </pre>
+    <pre><code>scheme:prefix/value</code></pre>
         <p><em>Note:</em> The legacy N2T service is deprecated. The following resources are transitioned:</p>
         <ul>
             <li><a href="https://cdluc3.github.io/naan_reg_priv/naan_registry.txt">naan_registry.txt</a></li>

--- a/n2t/templates/schemes.html
+++ b/n2t/templates/schemes.html
@@ -16,9 +16,7 @@
     <h1>N2T - Registered Schemes</h1>
     <div>
     <p>Identifiers take the form:</p>
-    <pre>
-scheme:prefix/value
-    </pre>
+    <pre><code>scheme:prefix/value</code></pre>
         <p>N2T associates identifier schemes with resolver services. The resolver services are dedicated to
             supporting particular schemes and provide the capabilities necessary for further resolving identifiers
             to specific resources.</p>

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "n2t"
-version = "0.12.1"
+version = "0.12.2"
 description = "Implementation of N2T in python"
 authors = [{ name = "datadavev", email = "605409+datadavev@users.noreply.github.com" }]
 requires-python = ">=3.9,<4.0"

--- a/uv.lock
+++ b/uv.lock
@@ -379,7 +379,7 @@ wheels = [
 
 [[package]]
 name = "n2t"
-version = "0.12.1"
+version = "0.12.2"
 source = { editable = "." }
 dependencies = [
     { name = "aiosqlite" },


### PR DESCRIPTION
## Summary

- Adds the UC-mandated accessibility statement to N2T.net as a dedicated page (`/_accessibility.html`), linked from both the modern (FastAPI/Jinja2) footer and the legacy `/e/` footer.
- Fixes a WCAG 1.4.3 (contrast) failure: identifier-format examples used a bare `<pre>` whose `color: #222` is not overridden in dark mode (only `pre code` is), rendering near-black text on a near-black background. Wrapping the content in `<pre><code>` resolves both the contrast issue and the `<code>` semantics (WCAG 1.3.1).

## Changes

- **New** `n2t/templates/accessibility.html`- accessibility statement page, served by the existing `human_pages()` route.
- `n2t/templates/base.html` - footer "Accessibility" link.
- `legacy_e_files/e/footer.html`- legacy footer "Accessibility Statement" link.
- `n2t/templates/index.html`, `schemes.html`, `base.html`- `<pre>` -> `<pre><code>` for identifier examples.
